### PR TITLE
Fix mypy-extensions version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'Markdown>=3.1.1',
         'beautifulsoup4>=4.8.0',
         'esprima==4.0.1',
-        'mypy-extensions==0.4.1',
+        'mypy-extensions>=0.4.1',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Package mypy-extensions has version 0.4.3 in requirements.txt and mypy has version 0.770. But version 0.4.1 of mypy-extensions in setup.py is not compatible with mypy 0.770.